### PR TITLE
fix to include statement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```puppet
-include Libreoffice
+include libreoffice
 ```
 
 ## Required Puppet Modules


### PR DESCRIPTION
Shouldn't this be 'libreoffice'?
