### PR TITLE
Stable version of LibreOffice is now 4.0.2 and 4.0.1 no longer exists.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,6 @@
 class libreoffice {
   package { 'libreoffice':
     provider => 'appdmg',
-    source => 'http://download.documentfoundation.org/libreoffice/stable/4.0.1/mac/x86/LibreOffice_4.0.1_MacOS_x86.dmg'
+    source => 'http://download.documentfoundation.org/libreoffice/stable/4.0.2/mac/x86/LibreOffice_4.0.2_MacOS_x86.dmg' 
   }
 }


### PR DESCRIPTION
The URL for 4.0.1 now returns a 404 so Boxen falls over if this module is included. 

This fix updates the URL to the current stable release. 
